### PR TITLE
Collapsable assignment autoevent lists

### DIFF
--- a/Studium/Controllers/Form Controllers/AddAssignmentViewController.swift
+++ b/Studium/Controllers/Form Controllers/AddAssignmentViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 import RealmSwift
 
 protocol AssignmentRefreshProtocol{
-    func loadAssignments(skipAutos: Bool)
+    func loadAssignments()
 }
 
 class AddAssignmentViewController: MasterForm, AlertInfoStorer{
@@ -160,7 +160,7 @@ class AddAssignmentViewController: MasterForm, AlertInfoStorer{
                     print("there was an error: \(error)")
                 }
             }
-            delegate?.loadAssignments(skipAutos: true)
+            delegate?.loadAssignments()
             dismiss(animated: true, completion: nil)
         }else{
             cellText[3][1] = errors

--- a/Studium/Controllers/Form Controllers/AddAssignmentViewController.swift
+++ b/Studium/Controllers/Form Controllers/AddAssignmentViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 import RealmSwift
 
 protocol AssignmentRefreshProtocol{
-    func loadAssignments()
+    func loadAssignments(skipAutos: Bool)
 }
 
 class AddAssignmentViewController: MasterForm, AlertInfoStorer{
@@ -160,7 +160,7 @@ class AddAssignmentViewController: MasterForm, AlertInfoStorer{
                     print("there was an error: \(error)")
                 }
             }
-            delegate?.loadAssignments()
+            delegate?.loadAssignments(skipAutos: true)
             dismiss(animated: true, completion: nil)
         }else{
             cellText[3][1] = errors
@@ -177,7 +177,6 @@ class AddAssignmentViewController: MasterForm, AlertInfoStorer{
     func setDefaultRow(picker: UIPickerView){
         var row = 0
         if selectedCourse == nil{
-//            print("selectedCourse is nil. User probably initiated this form from the general add event form")
             return
         }
         if let coursesArr = courses{
@@ -210,11 +209,6 @@ class AddAssignmentViewController: MasterForm, AlertInfoStorer{
         dueDateCell.date = dueDate
         
         self.alertTimes = alertTimes
-//        alertTimes = []
-//        for alert in assignment.notificationAlertTimes{
-//            alertTimes.append(alert)
-//        }
-        
         
         self.scheduleWorkTime = scheduleWorkTime
         if scheduleWorkTime == true{

--- a/Studium/Controllers/List Controllers/AssignmentsViewController.swift
+++ b/Studium/Controllers/List Controllers/AssignmentsViewController.swift
@@ -214,7 +214,7 @@ extension AssignmentsViewController: AssignmentCollapseDelegate{
         print("Handle opening auto events")
         
         if let ind = assignmentsArr[arrayIndex].firstIndex(of: assignment){
-            var index = ind
+            var index = ind + 1
             for auto in assignment.scheduledEvents{
                 assignmentsArr[arrayIndex].insert(auto, at: index)
                 index += 1
@@ -237,6 +237,7 @@ extension AssignmentsViewController: AssignmentCollapseDelegate{
 //            assignmentsArr[arrayIndex].insert(auto, at: index)
 //            index += 1
         }
+        tableView.reloadData()
     }
     
     

--- a/Studium/Controllers/List Controllers/ToDoListViewController.swift
+++ b/Studium/Controllers/List Controllers/ToDoListViewController.swift
@@ -226,7 +226,7 @@ class ToDoListViewController: SwipeTableViewController, ToDoListRefreshProtocol{
 }
 
 extension ToDoListViewController: AssignmentRefreshProtocol{
-    func loadAssignments(skipAutos: Bool) {
+    func loadAssignments() {
         refreshData()
     }
 }

--- a/Studium/Controllers/List Controllers/ToDoListViewController.swift
+++ b/Studium/Controllers/List Controllers/ToDoListViewController.swift
@@ -226,7 +226,7 @@ class ToDoListViewController: SwipeTableViewController, ToDoListRefreshProtocol{
 }
 
 extension ToDoListViewController: AssignmentRefreshProtocol{
-    func loadAssignments() {
+    func loadAssignments(skipAutos: Bool) {
         refreshData()
     }
 }

--- a/Studium/Views/Basic Cells/TimePickerCell.swift
+++ b/Studium/Views/Basic Cells/TimePickerCell.swift
@@ -7,9 +7,11 @@
 //
 
 import UIKit
+
 protocol UITimePickerDelegate {
     func pickerValueChanged(sender: UIDatePicker, indexPath: IndexPath)
 }
+
 class TimePickerCell: BasicCell {
     @IBOutlet weak var picker: UIDatePicker!
     

--- a/Studium/Views/New Event Cells/AssignmentCell1.swift
+++ b/Studium/Views/New Event Cells/AssignmentCell1.swift
@@ -8,6 +8,12 @@
 
 import UIKit
 import SwipeCellKit
+
+protocol AssignmentCollapseDelegate{
+    func handleOpenAutoEvents(assignment: Assignment)
+    func handleCloseAutoEvents(assignment: Assignment)
+}
+
 class AssignmentCell1: DeletableEventCell {
 
     @IBOutlet weak var background: UIImageView!
@@ -17,18 +23,18 @@ class AssignmentCell1: DeletableEventCell {
     @IBOutlet weak var courseNameLabel: UILabel!
     @IBOutlet weak var dueDateLabel: UILabel!
     
+    @IBOutlet weak var chevronButton: UIButton!
+    var assignmentCollapseDelegate: AssignmentCollapseDelegate?
+    var autoEventsOpen: Bool = false
+    
     var assignment: Assignment?
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        
-        // Initialization code
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
     }
     
     func loadData(assignment: Assignment){
@@ -45,13 +51,16 @@ class AssignmentCell1: DeletableEventCell {
             background.backgroundColor = .gray
             assignmentNameLabel.attributedText = attributeString
             icon.tintColor = .gray
-
-
         }else{
             background.backgroundColor = UIColor(hexString: course.color)
             attributeString.removeAttribute(NSAttributedString.Key.strikethroughStyle, range: NSMakeRange(0, attributeString.length))
             assignmentNameLabel.attributedText = attributeString
             icon.tintColor = UIColor(hexString: course.color)
+        }
+        
+        if assignment.scheduledEvents.count == 0{
+            print("there are no assignment scheduled events")
+//            chevronButton.isHidden = true
         }
         self.assignment = assignment
         self.event = assignment
@@ -61,5 +70,24 @@ class AssignmentCell1: DeletableEventCell {
         
         
         dueDateLabel.text = assignment.endDate.format(with: "MMM d, h:mm a")
+    }
+    
+    @IBAction func collapseButtonPressed(_ sender: UIButton) {
+        print("Collapse Button Pressed")
+        if assignmentCollapseDelegate != nil && assignment != nil{
+
+            if autoEventsOpen{
+                //handle closing the window
+                assignmentCollapseDelegate?.handleCloseAutoEvents(assignment: assignment!)
+                autoEventsOpen = false
+                
+            }else{
+                //handle opening the window
+                assignmentCollapseDelegate?.handleOpenAutoEvents(assignment: assignment!)
+                autoEventsOpen = true
+            }
+        }else{
+            print("delegate was nil or assignment was nil")
+        }
     }
 }

--- a/Studium/Views/New Event Cells/AssignmentCell1.swift
+++ b/Studium/Views/New Event Cells/AssignmentCell1.swift
@@ -60,7 +60,7 @@ class AssignmentCell1: DeletableEventCell {
         
         if assignment.scheduledEvents.count == 0{
             print("there are no assignment scheduled events")
-//            chevronButton.isHidden = true
+            chevronButton.isHidden = true
         }
         self.assignment = assignment
         self.event = assignment
@@ -80,11 +80,14 @@ class AssignmentCell1: DeletableEventCell {
                 //handle closing the window
                 assignmentCollapseDelegate?.handleCloseAutoEvents(assignment: assignment!)
                 autoEventsOpen = false
+                chevronButton.setImage(UIImage(systemName: "chevron.down"), for: .normal)
                 
             }else{
                 //handle opening the window
                 assignmentCollapseDelegate?.handleOpenAutoEvents(assignment: assignment!)
                 autoEventsOpen = true
+                chevronButton.setImage(UIImage(systemName: "chevron.up"), for: .normal)
+
             }
         }else{
             print("delegate was nil or assignment was nil")

--- a/Studium/Views/New Event Cells/AssignmentCell1.xib
+++ b/Studium/Views/New Event Cells/AssignmentCell1.xib
@@ -21,9 +21,6 @@
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="eJZ-Bg-Kz8">
                         <rect key="frame" x="0.0" y="0.0" width="490" height="257"/>
                         <color key="backgroundColor" systemColor="linkColor"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="490" id="fdw-iP-L5O"/>
-                        </constraints>
                     </imageView>
                     <stackView opaque="NO" contentMode="left" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="M7B-77-8fv">
                         <rect key="frame" x="69" y="103.5" width="352" height="50"/>

--- a/Studium/Views/New Event Cells/AssignmentCell1.xib
+++ b/Studium/Views/New Event Cells/AssignmentCell1.xib
@@ -21,9 +21,12 @@
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="eJZ-Bg-Kz8">
                         <rect key="frame" x="0.0" y="0.0" width="490" height="257"/>
                         <color key="backgroundColor" systemColor="linkColor"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="490" id="fdw-iP-L5O"/>
+                        </constraints>
                     </imageView>
                     <stackView opaque="NO" contentMode="left" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="M7B-77-8fv">
-                        <rect key="frame" x="20" y="103.5" width="445" height="50"/>
+                        <rect key="frame" x="69" y="103.5" width="352" height="50"/>
                         <subviews>
                             <view contentMode="left" translatesAutoresizingMaskIntoConstraints="NO" id="u9D-Ia-LNc">
                                 <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -44,25 +47,25 @@
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="IUd-aq-cj6">
-                                <rect key="frame" x="65" y="0.0" width="380" height="50"/>
+                                <rect key="frame" x="65" y="0.0" width="222" height="50"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Homework 4 Primer" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pF6-1U-gVs">
-                                        <rect key="frame" x="0.0" y="0.0" width="380" height="25.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="222" height="25.5"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Yeo-7f-SgP">
-                                        <rect key="frame" x="0.0" y="28.5" width="380" height="21.5"/>
+                                        <rect key="frame" x="0.0" y="28.5" width="222" height="21.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="COMPSCI 383" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wuB-Zg-viJ">
-                                                <rect key="frame" x="0.0" y="0.0" width="190" height="21.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="111" height="21.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="March 18 4:45" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Syo-Rz-w2J">
-                                                <rect key="frame" x="190" y="0.0" width="190" height="21.5"/>
+                                                <rect key="frame" x="111" y="0.0" width="111" height="21.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -71,16 +74,33 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EIm-12-tok">
+                                <rect key="frame" x="302" y="0.0" width="50" height="50"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="50" id="pOu-zI-a7S"/>
+                                    <constraint firstAttribute="height" constant="50" id="peH-Sf-fA9"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="26"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" image="chevron.down" catalog="system"/>
+                                <connections>
+                                    <action selector="collapseButtonPressed:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="A5o-az-lRk"/>
+                                </connections>
+                            </button>
                         </subviews>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="EIm-12-tok" secondAttribute="trailing" id="3dm-fB-Qzy"/>
+                            <constraint firstItem="EIm-12-tok" firstAttribute="centerY" secondItem="M7B-77-8fv" secondAttribute="centerY" id="LVV-ZJ-Bij"/>
+                            <constraint firstItem="EIm-12-tok" firstAttribute="centerY" secondItem="M7B-77-8fv" secondAttribute="centerY" id="w6z-H3-FFP"/>
+                        </constraints>
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="M7B-77-8fv" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="M6d-Jw-bSl"/>
+                    <constraint firstItem="M7B-77-8fv" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="OSw-Ca-AuD"/>
                     <constraint firstItem="eJZ-Bg-Kz8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="YYa-nj-5VH"/>
+                    <constraint firstItem="M7B-77-8fv" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="ZfA-lw-YA7"/>
                     <constraint firstAttribute="bottom" secondItem="eJZ-Bg-Kz8" secondAttribute="bottom" id="dAF-Lc-FcV"/>
-                    <constraint firstItem="M7B-77-8fv" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="ns6-Ce-aaa"/>
                     <constraint firstAttribute="trailing" secondItem="eJZ-Bg-Kz8" secondAttribute="trailing" id="r2E-LI-G3r"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="M7B-77-8fv" secondAttribute="trailing" constant="5" id="rjR-7T-ih7"/>
                     <constraint firstItem="eJZ-Bg-Kz8" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="tjq-63-ybm"/>
                 </constraints>
             </tableViewCellContentView>
@@ -88,14 +108,16 @@
             <connections>
                 <outlet property="assignmentNameLabel" destination="pF6-1U-gVs" id="hkX-IQ-E1u"/>
                 <outlet property="background" destination="eJZ-Bg-Kz8" id="osO-d6-n4X"/>
+                <outlet property="chevronButton" destination="EIm-12-tok" id="y3q-Xl-kY0"/>
                 <outlet property="courseNameLabel" destination="wuB-Zg-viJ" id="kav-49-E8D"/>
                 <outlet property="dueDateLabel" destination="Syo-Rz-w2J" id="XxX-1p-xFd"/>
                 <outlet property="icon" destination="PA4-b9-1uZ" id="YY5-bY-Teo"/>
             </connections>
-            <point key="canvasLocation" x="160.86956521739131" y="81.361607142857139"/>
+            <point key="canvasLocation" x="153.62318840579712" y="64.620535714285708"/>
         </tableViewCell>
     </objects>
     <resources>
+        <image name="chevron.down" catalog="system" width="128" height="72"/>
         <image name="circle.fill" catalog="system" width="128" height="121"/>
         <image name="pencil" catalog="system" width="128" height="113"/>
         <systemColor name="linkColor">


### PR DESCRIPTION
Implement basic functionality of collapsable assignment autoevent lists. If an assignment has autoscheduled work time events, they are stored within that assignment and can be expanded and collapsed via the assignment's cell (so that the assignments view isn't flooded by autoscheduled events)